### PR TITLE
Ignore unknown compression types

### DIFF
--- a/karton/archive_extractor/sflock/unpack/zip.py
+++ b/karton/archive_extractor/sflock/unpack/zip.py
@@ -56,6 +56,8 @@ class ZipFile(Unpacker):
                 return
             if "Bad magic number for" in msg:
                 return
+            if "compression type" in msg:
+                return
 
             raise UnpackException("Unknown zipfile error: %s" % e)
 


### PR DESCRIPTION
It seems that the zip module is having issues with archives encrypted with AES