### PR TITLE
Add reading password from attributes

### DIFF
--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -28,10 +28,10 @@ class ArchiveExtractor(Karton):
         sample = task.get_resource("sample")
         task_password = task.get_payload("password", default=None)
         
-        attributes_password = task.get_payload("attributes", default=None)
-        if not task_password and attributes_password and "password" in attributes_password:
-            self.log.info("Taking password from attributes")
-            task_password = (attributes_password["password"] or [None])[0]
+        attributes = task.get_payload("attributes", default={})
+        if not task_password and attributes.get("password"):
+            self.log.info("Accepting password from attributes")
+            task_password = attributes.get("password")[0]
 
         try:
             if sample.name:

--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -27,6 +27,11 @@ class ArchiveExtractor(Karton):
     def process(self, task: Task) -> None:
         sample = task.get_resource("sample")
         task_password = task.get_payload("password", default=None)
+        
+        attributes_password = task.get_payload("attributes", default=None)
+        if not task_password and attributes_password and "password" in attributes_password:
+            self.log.info("Taking password from attributes")
+            task_password = (attributes_password["password"] or [None])[0]
 
         try:
             if sample.name:


### PR DESCRIPTION
Allows uploading encrypted archives (ex. zip file encrypted with ZipCrypto)
via MWDB with password set as attribute

Note: 7z encrypted archives with AES (filenames encryption enabled) are not supported