### PR TITLE
Added a limitation for number of childs

### DIFF
--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -17,7 +17,7 @@ class ArchiveExtractor(Karton):
     # Maximum unpacked child filesize, larger files are not reported
     max_size = 25 * 1024 * 1024
     # Maximum number of childs for further analysis
-    max_childs = 1000
+    max_children = 1000
 
     identity = "karton.archive-extractor"
     version = __version__
@@ -86,8 +86,8 @@ class ArchiveExtractor(Karton):
             self.log.warning("Don't know how to unpack this archive")
             return
 
-        if len(unpacked.children) > self.max_childs:
-            self.log.warning("Too many childs for further processing")
+        if len(unpacked.children) > self.max_children:
+            self.log.warning("Too many children for further processing")
             return
 
         for child in unpacked.children:

--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -16,6 +16,8 @@ class ArchiveExtractor(Karton):
     max_depth = 5
     # Maximum unpacked child filesize, larger files are not reported
     max_size = 25 * 1024 * 1024
+    # Maximum number of childs for further analysis
+    max_childs = 1000
 
     identity = "karton.archive-extractor"
     version = __version__
@@ -82,6 +84,10 @@ class ArchiveExtractor(Karton):
 
         if not unpacked.children:
             self.log.warning("Don't know how to unpack this archive")
+            return
+
+        if len(unpacked.children) > self.max_childs:
+            self.log.warning("Too many childs for further processing")
             return
 
         for child in unpacked.children:


### PR DESCRIPTION
We had some issues in our internal karton system in which a rather small ZIP file contained hundreds of thousands of files crashed the system, so we found it would be wise to make a limitation on the maximum childs an archive can have.

Feel free to modify the limit.

Tested functionality in docker environment.