### PR TITLE
Catch extraction exceptions

### DIFF
--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -66,11 +66,16 @@ class ArchiveExtractor(Karton):
             if task_password is not None:
                 archive_password = task_password
 
-            unpacked = unpack(
-                filename=fname,
-                filepath=filepath.encode("utf-8"),
-                password=archive_password,
-            )
+            try:
+                unpacked = unpack(
+                    filename=fname,
+                    filepath=filepath.encode("utf-8"),
+                    password=archive_password,
+                )
+            except Exception as e:
+                # we can't really do anything about corrupted archives :(
+                self.log.warning("Error while unpacking archive: %s", e)
+                return
 
         try:
             fname = (


### PR DESCRIPTION
I don't think we have differentiate between various archive fails since we the error information is not actionable anyway.