### PR TITLE
Fix sflock str-vs-bytes usage

### DIFF
--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -65,7 +65,7 @@ class ArchiveExtractor(Karton):
 
             # sflock gets very angry if the filename isn't bytes, for some reason
             if type(fname) is str:
-                `fname` = fname.encode()
+                fname = fname.encode()
 
             try:
                 unpacked = unpack(

--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -19,9 +19,9 @@ class ArchiveExtractor(Karton):
     # Maximum number of childs for further analysis
     max_children = 1000
 
-    identity = "karton.archive-extractor"
+    identity = "karton.archive-extractor-nazywam-dev"
     version = __version__
-    persistent = True
+    persistent = False
     filters = [
         {"type": "sample", "stage": "recognized", "kind": "archive"},
     ]
@@ -62,6 +62,10 @@ class ArchiveExtractor(Karton):
             archive_password = None
             if task_password is not None:
                 archive_password = task_password
+
+            # sflock gets very angry if the filename isn't bytes, for some reason
+            if type(fname) is str:
+                fname = fname.encode()
 
             try:
                 unpacked = unpack(

--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -63,13 +63,9 @@ class ArchiveExtractor(Karton):
             if task_password is not None:
                 archive_password = task_password
 
-            # sflock gets very angry if the filename isn't bytes, for some reason
-            if type(fname) is str:
-                fname = fname.encode()
-
             try:
                 unpacked = unpack(
-                    filename=fname,
+                    filename=fname.encode("utf-8"),
                     filepath=filepath.encode("utf-8"),
                     password=archive_password,
                 )

--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -19,9 +19,9 @@ class ArchiveExtractor(Karton):
     # Maximum number of childs for further analysis
     max_children = 1000
 
-    identity = "karton.archive-extractor-nazywam-dev"
+    identity = "karton.archive-extractor"
     version = __version__
-    persistent = False
+    persistent = True
     filters = [
         {"type": "sample", "stage": "recognized", "kind": "archive"},
     ]
@@ -65,7 +65,7 @@ class ArchiveExtractor(Karton):
 
             # sflock gets very angry if the filename isn't bytes, for some reason
             if type(fname) is str:
-                fname = fname.encode()
+                `fname` = fname.encode()
 
             try:
                 unpacked = unpack(


### PR DESCRIPTION
The `filename` parameter needs to always be bytes[1]

[1] https://github.com/doomedraven/sflock/blob/master/sflock/main.py#L61