### PR TITLE
Initialise archive file name in all code paths

### DIFF
--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -35,6 +35,7 @@ class ArchiveExtractor(Karton):
             self.log.info("Accepting password from attributes")
             task_password = attributes.get("password")[0]
 
+        fname = "archive"
         try:
             if sample.name:
                 fname = sample.name
@@ -44,7 +45,6 @@ class ArchiveExtractor(Karton):
                     fname += classifier_extension
         except Exception as e:
             self.log.warning("Exception during extraction: %r", e)
-            fname = "archive"
 
         extraction_level = task.get_payload("extraction_level", 0)
 

--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -40,9 +40,9 @@ class ArchiveExtractor(Karton):
             if sample.name:
                 fname = sample.name
 
-                classifier_extension = "." + task.headers["extension"]
-                if classifier_extension and not fname.endswith(classifier_extension):
-                    fname += classifier_extension
+            classifier_extension = "." + task.headers["extension"]
+            if classifier_extension and not fname.endswith(classifier_extension):
+                fname += classifier_extension
         except Exception as e:
             self.log.warning("Exception during extraction: %r", e)
 

--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -40,9 +40,11 @@ class ArchiveExtractor(Karton):
             if sample.name:
                 fname = sample.name
 
-            classifier_extension = "." + task.headers["extension"]
-            if classifier_extension and not fname.endswith(classifier_extension):
-                fname += classifier_extension
+            classifier_extension = task.headers.get("extension")
+            if classifier_extension:
+                classifier_extension = "." + classifier_extension
+                if not fname.endswith(classifier_extension):
+                    fname += classifier_extension
         except Exception as e:
             self.log.warning("Exception during extraction: %r", e)
 


### PR DESCRIPTION
Variable fname will stay uninitialised if the sample has no name. This
will lead to an exception further down when the local file name is
constructed for extraction:

``` python
[ERROR] karton.archive-extractor: Failed to process task - 4900d4bd-13d7-406e-b7f3-e2f195b63769
Traceback (most recent call last):
  File "/opt/karton-archive-extractor/lib/python3.8/site-packages/karton/core/karton.py", line 178, in internal_process
self.process(self.current_task)
  File "/opt/karton-archive-extractor/lib/python3.8/site-packages/karton/archive_extractor/archive_extractor.py", line 58, in process
    filepath = f"{dir_name}/{fname}"
UnboundLocalError: local variable 'fname' referenced before assignment
```

This can be avoided by initialising the variable name beforehand so it
is always initialised and only overridden in the case that a sample name
is at hand.

Related question: Should maybe that default archive name also be supplemented with the classifier extension if available? Something like so:

``` diff
diff --git a/karton/archive_extractor/archive_extractor.py b/karton/archive_extractor/archive_extractor.py
index 190457a..e460937 100644
--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -40,9 +40,9 @@ class ArchiveExtractor(Karton):
             if sample.name:
                 fname = sample.name
 
-                classifier_extension = "." + task.headers["extension"]
-                if classifier_extension and not fname.endswith(classifier_extension):
-                    fname += classifier_extension
+            classifier_extension = "." + task.headers["extension"]
+            if classifier_extension and not fname.endswith(classifier_extension):
+                fname += classifier_extension
         except Exception as e:
             self.log.warning("Exception during extraction: %r", e)
 ```