### PR TITLE
CI: Disable provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,9 @@ on:
   push:
     branches:
     - master
-    - ci/*
   pull_request:
     branches:
     - master
-    - ci/*
 jobs:
   build_core:
     name: Build image


### PR DESCRIPTION
- Bumped action versions
- Disabled default `provenance` because it generates manifest in format that is incompatible with Flux v1:
   `"mediaType": "application/vnd.docker.distribution.manifest.v2+json"`
   vs
   ` "mediaType": "application/vnd.oci.image.index.v1+json"`
   in `docker manifest inspect certpl/karton-archive-extractor:462602c98dd4b9356482bdce2536a0b85658260e`
- Removed unneeded environment variable enabling buildkit explicitly