### PR TITLE
Improve handling of NSIS archives in debloat

### DIFF
--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -84,11 +84,12 @@ class ArchiveExtractor(Karton):
 
             # debloat can sometimes unpack NSIS installer archives but we're interested
             # only in the installer script
-            for f_name in (filename, "Setup.NSIS"):
-                unpacked_file = Path(tmp_dir) / f_name
+            for unpacked_file in Path(tmp_dir).rglob("*"):
+                if unpacked_file.is_dir():
+                    continue
 
-                if unpacked_file.exists() and unpacked_file.stat().st_size:
-                    return (f_name, unpacked_file.read_bytes())
+                if unpacked_file.name == filename or unpacked_file.name.lower() == "setup.nsis":
+                    return (unpacked_file.name, unpacked_file.read_bytes())
 
         self.log.warning("Output file is empty - failed to debloat file")
         return None

--- a/karton/archive_extractor/archive_extractor.py
+++ b/karton/archive_extractor/archive_extractor.py
@@ -88,7 +88,10 @@ class ArchiveExtractor(Karton):
                 if unpacked_file.is_dir():
                     continue
 
-                if unpacked_file.name == filename or unpacked_file.name.lower() == "setup.nsis":
+                if (
+                    unpacked_file.name == filename
+                    or unpacked_file.name.lower() == "setup.nsis"
+                ):
                     return (unpacked_file.name, unpacked_file.read_bytes())
 
         self.log.warning("Output file is empty - failed to debloat file")


### PR DESCRIPTION
* In some scenarios the directory containing some unpacked files can have the same name as the original executable
* File containing the NSIS setup script can have various capitalizations

```
[2024-02-04 12:46:36,012][INFO] The files are being written to /tmp/tmpxv8g0wj6/Steup The Damned.exe
[2024-02-04 12:46:36,013][INFO] File: $PLUGINSDIR/StdUtils.dll
[2024-02-04 12:46:36,014][INFO] File: $PLUGINSDIR/System.dll
[2024-02-04 12:46:36,079][INFO] File: $PLUGINSDIR/app-64.7z
[2024-02-04 12:46:36,081][INFO] File: $PLUGINSDIR/nsis7z.dll
[2024-02-04 12:46:36,082][INFO] File: setup.nsis
[2024-02-04 12:46:36,082][INFO]
[2024-02-04 12:46:36,082][INFO] The user will need to determine which file is malicious if any.
[2024-02-04 12:46:36,083][INFO] If a file is bloated: resubmit it through the tool to debloat it.
[2024-02-04 12:46:36,083][INFO] Consider reviewing the 'setup.nsis' from the installer to determine how the files were meant to be used.
[2024-02-04 12:46:36,097][ERROR] Failed to process task - e25994f0-8a5e-45c0-9e25-9cb26ef97e2b
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/karton/core/karton.py", line 181, in internal_process
    self.process(self.current_task)
  File "/usr/local/lib/python3.10/site-packages/karton/archive_extractor/archive_extractor.py", line 179, in process
    debloated = self.debloat_pe(fname, contents)
  File "/usr/local/lib/python3.10/site-packages/karton/archive_extractor/archive_extractor.py", line 91, in debloat_pe
    return (f_name, unpacked_file.read_bytes())
  File "/usr/local/lib/python3.10/pathlib.py", line 1126, in read_bytes
    with self.open(mode='rb') as f:
  File "/usr/local/lib/python3.10/pathlib.py", line 1119, in open
    return self._accessor.open(self, mode, buffering, encoding, errors,
IsADirectoryError: [Errno 21] Is a directory: '/tmp/tmpxv8g0wj6/Steup The Damned.exe'
```