### PR TITLE
Bump SFLock2 to 0.3.85

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 karton-core>=5.0.0,<6.0.0
-SFlock2[linux]==0.3.80
+SFlock2[linux]==0.3.85


### PR DESCRIPTION
Fixes: No such file and directory 'sflock/data/password.txt' (https://github.com/CAPESandbox/sflock/pull/63)

But currently breaks another thing: sflock 0.3.81 doesn't handle default passwords e.g. "infected" (https://github.com/CAPESandbox/sflock/releases/tag/v0.3.81). Previously it was handled inconsistently so it's not a bad thing, but it also means that we need to handle it in karton-archive-extractor.

